### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/client_build.yml
+++ b/.github/workflows/client_build.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Build/Publish Client Docker
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: jeffvalore/k8s-when-ready
           username: jeffvalore

--- a/.github/workflows/server_build.yml
+++ b/.github/workflows/server_build.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Build/Publish Server Docker
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: jeffvalore/k8s-when-ready-server
           username: jeffvalore


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore